### PR TITLE
feat: Add mandatory branch safety check to commit command

### DIFF
--- a/commands/commit.md
+++ b/commands/commit.md
@@ -4,8 +4,12 @@ When you want Claude to automatically commit code changes with an appropriate me
 `/commit`
 
 **Commit workflow (all steps REQUIRED):**
-1. Run `git diff` to analyze changes
-2. Perform comprehensive change analysis:
+1. **🚨 MANDATORY SAFETY CHECK**: Check current branch with `git branch --show-current`
+   - **IMMEDIATELY REFUSE** if on `main` branch - commits to main are NEVER allowed
+   - Display error: "❌ ERROR: Cannot commit to main branch. Please create a feature branch first."
+   - Stop execution completely - do not proceed with any other steps
+2. Run `git diff` to analyze changes
+3. Perform comprehensive change analysis:
    - **Identify primary purpose**: What is the main goal of these changes?
    - **Detect new capabilities**: Look for added functions, methods, options, or features
    - **Recognize patterns**:
@@ -13,20 +17,20 @@ When you want Claude to automatically commit code changes with an appropriate me
      - Added conditionals/validations often indicate new constraints or safeguards
      - New parameters/options suggest enhanced functionality
    - **Weigh significance**: Features > fixes > improvements > refactors > docs > style
-3. Automatically detect the commit type (feat/fix/docs/chore/refactor/test):
+4. Automatically detect the commit type (feat/fix/docs/chore/refactor/test):
    - feat: New functionality or capabilities added
    - fix: Bug fixes or corrections
    - docs: ONLY if changes are purely documentation with no functional impact
    - refactor: Code restructuring without changing functionality
    - test: Adding or modifying tests
    - chore: Maintenance tasks, dependency updates
-4. Generate a descriptive commit message that:
+5. Generate a descriptive commit message that:
    - **Title**: Max 50 characters (imperative mood: "Add", not "Added")
    - Highlights the most impactful change
    - Explains what was added/changed and why (when apparent)
    - Keeps secondary changes in the body, not the title
-5. Execute the git commit
-6. **🚨 MANDATORY: MUST update session context** `SESSION_CONTEXT.md` (runs `/update-session`) with commit details - DO NOT skip this step
+6. Execute the git commit
+7. **🚨 MANDATORY: MUST update session context** `SESSION_CONTEXT.md` (runs `/update-session`) with commit details - DO NOT skip this step
 
 **⚠️ CRITICAL REMINDER: Every /commit command MUST end with updating SESSION_CONTEXT.md - this is not optional!**
 


### PR DESCRIPTION
## Summary
- Added mandatory safety check as first step in commit workflow to prevent commits to main branch
- Commits to main branch are now immediately refused with clear error message
- Updated step numbering throughout the workflow documentation

## Motivation and Context
Previously, the commit command could accidentally commit changes directly to the main branch, which poses risks to repository stability. This change ensures commits only happen on feature branches, enforcing proper Git workflow practices.

## Changes
- **feat**: Added mandatory branch validation step with `git branch --show-current`
- **feat**: Implemented immediate refusal mechanism for main branch commits
- **docs**: Updated all subsequent step numbers in commit workflow
- **docs**: Added clear error messaging and execution halt instructions

## Future Improvements
- Consider adding similar protections to other Git operations
- Could extend to protect other sensitive branches (develop, staging)
- Potential integration with branch naming conventions

## Risk Assessment
- **Low Risk**: This is a safety enhancement that prevents dangerous operations
- **Breaking Change**: None - only adds validation, doesn't change existing functionality
- **Testing**: Validated that branch check works correctly and error message displays

## Notes for Reviewers
- Verify the branch check logic is placed as the first mandatory step
- Confirm error messaging is clear and actionable
- Review that step numbering is correct throughout the document

🤖 Generated with [Claude Code](https://claude.ai/code)