### PR TITLE
feat(vault): age-encrypted JSONL archive + SessionStart hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ skills/*/.venv/
 skills/*/.git/
 /skills/review-pr/evals
 /skills/review-pr/review-pr-workspace
+/dot-claude-global/vault/encrypt.log

--- a/dot-claude-global/CLAUDE.md
+++ b/dot-claude-global/CLAUDE.md
@@ -46,4 +46,4 @@ The summary is a concise list of what the PR actually does. Keep it to bullet po
 
 ## Memories
 
-- Do not write new memories without first asking the user.
+- Never write, overwrite, or delete any memory file without explicitly confirming with the user first via AskUserQuestion. This is imperative — no exceptions.

--- a/dot-claude-global/settings.json
+++ b/dot-claude-global/settings.json
@@ -1,16 +1,16 @@
 {
   "env": {
+    "_DISABLED_CLAUDE_CODE_MAX_OUTPUT_TOKENS": "128000",
+    "_DISABLED_CLAUDE_CODE_EFFORT_LEVEL": "max",
+    "_DISABLED_CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "true",
+    "_DISABLED_MAX_THINKING_TOKENS": "64000",
+    "_DISABLED_DISABLE_TELEMETRY": "1",
     "ENABLE_TOOL_SEARCH": "true",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
-    "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "128000",
-    "CLAUDE_CODE_EFFORT_LEVEL": "max",
-    "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "true",
-    "MAX_THINKING_TOKENS": "64000",
     "CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY": "10",
     "CLAUDE_CODE_SUBAGENT_MODEL": "opus[1m]",
-    "DISABLE_TELEMETRY": "1",
     "CLAUDE_CODE_NO_FLICKER": "1",
-    "CLAUDE_CODE_SCROLL_SPEED": "4"
+    "CLAUDE_CODE_SCROLL_SPEED": "1"
   },
   "permissions": {
     "allow": [
@@ -405,6 +405,17 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/vault/bin/encrypt-old-sessions",
+            "async": true
+          }
+        ]
+      }
     ]
   },
   "statusLine": {
@@ -418,5 +429,8 @@
     "telegram@claude-plugins-official": true,
     "superpowers@claude-plugins-official": false
   },
-  "alwaysThinkingEnabled": true
+  "alwaysThinkingEnabled": true,
+  "effortLevel": "xhigh",
+  "cleanupPeriodDays": 1460,
+  "skipAutoPermissionPrompt": true
 }

--- a/dot-claude-global/vault/README.md
+++ b/dot-claude-global/vault/README.md
@@ -10,8 +10,9 @@ is deleted.
 - `bin/encrypt-old-sessions` — non-interactive. Runs on `SessionStart`. Uses
   the public recipient key only, no network needed.
 - `bin/decrypt-session` — on-demand. Takes one or more session ids or paths
-  and writes the plaintext alongside the `.age` file. Pass `--stdout` to
-  pipe the decrypted content to stdout instead of writing to disk.
+  and pipes the plaintext to stdout by default (never writes to disk). Pass
+  `--write` to restore plaintext alongside the `.age` file instead (for
+  un-archiving a session for `claude --resume`).
 
 Personal config (recipient key, private vault repo slug, log path) lives
 outside this repo in `~/.claude/vault-local/` and is not version-controlled
@@ -88,26 +89,26 @@ You need `age` (`brew install age`) and an authenticated `gh` CLI.
 
 After setup, encryption runs on every Claude Code session start via the hook.
 
-Decrypt a session on demand:
+Decrypt a session on demand (plaintext is piped to stdout — nothing lands
+on disk):
 
 ```bash
-~/.claude/vault/bin/decrypt-session <session-id>
-# or
-~/.claude/vault/bin/decrypt-session /path/to/file.jsonl.age
-```
-
-For search or inspection workflows where you don't want plaintext to
-land on disk, use `--stdout`:
-
-```bash
-~/.claude/vault/bin/decrypt-session --stdout <session-id> | grep 'foo'
+~/.claude/vault/bin/decrypt-session <session-id> | less
+~/.claude/vault/bin/decrypt-session /path/to/file.jsonl.age | grep 'foo'
 
 # bulk grep across the encrypted archive:
 for f in ~/.claude/projects/**/*.jsonl.age; do
-  if ~/.claude/vault/bin/decrypt-session --stdout "$f" | grep -q 'foo'; then
+  if ~/.claude/vault/bin/decrypt-session "$f" | grep -q 'foo'; then
     echo "$f"
   fi
 done
+```
+
+To restore plaintext alongside the `.age` (for example, to un-archive a
+session so `claude --resume` can read it), pass `--write`:
+
+```bash
+~/.claude/vault/bin/decrypt-session --write <session-id>
 ```
 
 ## Behaviour notes
@@ -120,8 +121,8 @@ done
 - Renamed `.age` files aren't recognised by Claude Code's built-in
   `cleanupPeriodDays` cleanup, so the encrypted archive is retained
   independently of that setting.
-- When `decrypt-session` writes plaintext alongside a `.age`, it sets the
-  plaintext mtime to match the `.age`. On the next `SessionStart`,
+- When `decrypt-session --write` restores plaintext alongside a `.age`, it
+  sets the plaintext mtime to match the `.age`. On the next `SessionStart`,
   `encrypt-old-sessions` reconciles any both-exist pair: plaintext
   strictly newer than the `.age` gets re-encrypted (capturing resumed
   sessions or manual edits) and replaces the `.age`; matching or older

--- a/dot-claude-global/vault/README.md
+++ b/dot-claude-global/vault/README.md
@@ -10,7 +10,8 @@ is deleted.
 - `bin/encrypt-old-sessions` — non-interactive. Runs on `SessionStart`. Uses
   the public recipient key only, no network needed.
 - `bin/decrypt-session` — on-demand. Takes one or more session ids or paths
-  and writes the plaintext alongside the `.age` file.
+  and writes the plaintext alongside the `.age` file. Pass `--stdout` to
+  pipe the decrypted content to stdout instead of writing to disk.
 
 Personal config (recipient key, private vault repo slug, log path) lives
 outside this repo in `~/.claude/vault-local/` and is not version-controlled
@@ -95,6 +96,20 @@ Decrypt a session on demand:
 ~/.claude/vault/bin/decrypt-session /path/to/file.jsonl.age
 ```
 
+For search or inspection workflows where you don't want plaintext to
+land on disk, use `--stdout`:
+
+```bash
+~/.claude/vault/bin/decrypt-session --stdout <session-id> | grep 'foo'
+
+# bulk grep across the encrypted archive:
+for f in ~/.claude/projects/**/*.jsonl.age; do
+  if ~/.claude/vault/bin/decrypt-session --stdout "$f" | grep -q 'foo'; then
+    echo "$f"
+  fi
+done
+```
+
 ## Behaviour notes
 
 - If `~/.claude/vault-local/config.sh` is missing, `encrypt-old-sessions`
@@ -105,3 +120,11 @@ Decrypt a session on demand:
 - Renamed `.age` files aren't recognised by Claude Code's built-in
   `cleanupPeriodDays` cleanup, so the encrypted archive is retained
   independently of that setting.
+- When `decrypt-session` writes plaintext alongside a `.age`, it sets the
+  plaintext mtime to match the `.age`. On the next `SessionStart`,
+  `encrypt-old-sessions` reconciles any both-exist pair: plaintext
+  strictly newer than the `.age` gets re-encrypted (capturing resumed
+  sessions or manual edits) and replaces the `.age`; matching or older
+  mtimes are treated as stale decrypt artifacts and the plaintext is
+  dropped. This runs on every `SessionStart`, regardless of cutoff age,
+  so the archive self-heals from forgotten decrypts.

--- a/dot-claude-global/vault/README.md
+++ b/dot-claude-global/vault/README.md
@@ -1,0 +1,107 @@
+# claude-vault
+
+Encrypt Claude Code session transcripts older than 21 days at rest using
+`age`. Recent sessions stay plaintext so `claude --resume` keeps working;
+older ones get renamed from `foo.jsonl` to `foo.jsonl.age` and the plaintext
+is deleted.
+
+## Layout
+
+- `bin/encrypt-old-sessions` — non-interactive. Runs on `SessionStart`. Uses
+  the public recipient key only, no network needed.
+- `bin/decrypt-session` — on-demand. Takes one or more session ids or paths
+  and writes the plaintext alongside the `.age` file.
+
+Personal config (recipient key, private vault repo slug, log path) lives
+outside this repo in `~/.claude/vault-local/` and is not version-controlled
+here. The scripts source `~/.claude/vault-local/config.sh` at runtime and
+exit cleanly if it's missing.
+
+## First-time setup
+
+You need `age` (`brew install age`) and an authenticated `gh` CLI.
+
+1. **Generate your keypair**:
+
+   ```bash
+   mkdir -p ~/.claude/vault-local && chmod 700 ~/.claude/vault-local
+   TMP=$(mktemp -d -t claude-vault.XXXXXX)
+   age-keygen -o "$TMP/identity.txt"
+   grep '^# public key: ' "$TMP/identity.txt" | sed 's/^# public key: //' \
+       > ~/.claude/vault-local/recipient.txt
+   chmod 600 ~/.claude/vault-local/recipient.txt
+   ```
+
+2. **Create a private vault repo** for your identity (replace `YOU`):
+
+   ```bash
+   gh repo create YOU/your-vault-repo --private
+   cd "$TMP"
+   git init && git remote add origin "https://github.com/YOU/your-vault-repo.git"
+   git add identity.txt && git -c commit.gpgsign=false commit -m "identity"
+   git push -u origin HEAD
+   cd - >/dev/null
+   rm -rf "$TMP"
+   ```
+
+3. **Write your local config** at `~/.claude/vault-local/config.sh`:
+
+   ```bash
+   # shellcheck shell=bash
+   export CLAUDE_VAULT_REPO="YOU/your-vault-repo"
+   export CLAUDE_VAULT_RECIPIENT="$HOME/.claude/vault-local/recipient.txt"
+   export CLAUDE_VAULT_LOG="$HOME/.claude/vault-local/encrypt.log"
+   export CLAUDE_VAULT_CUTOFF_DAYS="21"
+   ```
+
+4. **Symlink the public scripts** into `~/.claude/`:
+
+   ```bash
+   ln -s "$PWD/dot-claude-global/vault" ~/.claude/vault
+   ```
+
+5. **Wire the `SessionStart` hook** in `~/.claude/settings.json`:
+
+   ```json
+   "SessionStart": [
+     {
+       "hooks": [
+         { "type": "command",
+           "command": "~/.claude/vault/bin/encrypt-old-sessions",
+           "async": true }
+       ]
+     }
+   ]
+   ```
+
+6. **Dry-run first**:
+
+   ```bash
+   CLAUDE_VAULT_DRY_RUN=1 ~/.claude/vault/bin/encrypt-old-sessions
+   tail -20 ~/.claude/vault-local/encrypt.log
+   ```
+
+   Then run without `CLAUDE_VAULT_DRY_RUN` to encrypt the backlog.
+
+## Usage
+
+After setup, encryption runs on every Claude Code session start via the hook.
+
+Decrypt a session on demand:
+
+```bash
+~/.claude/vault/bin/decrypt-session <session-id>
+# or
+~/.claude/vault/bin/decrypt-session /path/to/file.jsonl.age
+```
+
+## Behaviour notes
+
+- If `~/.claude/vault-local/config.sh` is missing, `encrypt-old-sessions`
+  exits 0 with a stderr hint — `SessionStart` won't fail, and your JSONL
+  files stay plaintext until you finish setup.
+- If `CLAUDE_VAULT_REPO` is unset when you invoke `decrypt-session`, it
+  exits 1 with a setup message.
+- Renamed `.age` files aren't recognised by Claude Code's built-in
+  `cleanupPeriodDays` cleanup, so the encrypted archive is retained
+  independently of that setting.

--- a/dot-claude-global/vault/bin/decrypt-session
+++ b/dot-claude-global/vault/bin/decrypt-session
@@ -6,10 +6,31 @@
 #   decrypt-session <session-id>
 #   decrypt-session /path/to/file.jsonl.age
 #   decrypt-session <session-id-or-path> [<more>...]
+#   decrypt-session --stdout <session-id-or-path> [<more>...]
+#
+# With --stdout, plaintext is piped to stdout and never written to disk —
+# use this for search/inspection workflows that shouldn't leave decrypted
+# copies alongside the .age files (pipe directly into grep/jq/etc).
+#
+# Without --stdout, plaintext is written alongside the .age file and its
+# mtime is set to match the .age. On the next SessionStart the encrypt
+# hook treats the matching-mtime plaintext as a stale fresh-decrypt and
+# removes it; if you edit the plaintext (bumping mtime past the .age),
+# it gets re-encrypted instead.
 #
 # Identity retrieval requires `gh auth status` to be healthy.
 
 set -euo pipefail
+
+STDOUT_MODE=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stdout) STDOUT_MODE=1; shift ;;
+    --) shift; break ;;
+    --*) echo "Unknown flag: $1" >&2; exit 1 ;;
+    *) break ;;
+  esac
+done
 
 VAULT_LOCAL="${CLAUDE_VAULT_LOCAL_DIR:-$HOME/.claude/vault-local}"
 CONFIG="$VAULT_LOCAL/config.sh"
@@ -27,7 +48,7 @@ if [[ -z "$VAULT_REPO" ]]; then
 fi
 
 if [[ $# -eq 0 ]]; then
-  echo "Usage: $(basename "$0") <session-id-or-path> [<more>...]" >&2
+  echo "Usage: $(basename "$0") [--stdout] <session-id-or-path> [<more>...]" >&2
   exit 1
 fi
 
@@ -64,6 +85,14 @@ for arg in "$@"; do
     continue
   fi
 
+  if [[ "$STDOUT_MODE" == "1" ]]; then
+    if ! age -d -i "$identity_tmp" "$target"; then
+      echo "Decrypt failed: $target" >&2
+      status=1
+    fi
+    continue
+  fi
+
   out="${target%.age}"
   if [[ -e "$out" ]]; then
     echo "Plaintext already exists, refusing to overwrite: $out" >&2
@@ -72,6 +101,10 @@ for arg in "$@"; do
   fi
 
   if age -d -i "$identity_tmp" -o "$out" "$target"; then
+    # Align plaintext mtime with the .age so encrypt-old-sessions can
+    # tell "fresh decrypt" (mtimes equal -> drop) from "edited after
+    # decrypt" (plaintext newer -> re-encrypt).
+    touch -r "$target" "$out" 2>/dev/null || true
     echo "Decrypted: $out"
   else
     echo "Decrypt failed: $target" >&2

--- a/dot-claude-global/vault/bin/decrypt-session
+++ b/dot-claude-global/vault/bin/decrypt-session
@@ -59,6 +59,12 @@ if ! gh api "repos/${VAULT_REPO}/contents/identity.txt" --jq '.content' \
   exit 2
 fi
 
+# When running interactively (stdout is a terminal) in the default stdout
+# mode, hint once that --write is an option. Pipes and redirects stay quiet.
+if [[ "$WRITE_MODE" == "0" && -t 1 ]]; then
+  echo "decrypt-session: piping plaintext to stdout; pass --write to save alongside the .age instead." >&2
+fi
+
 resolve_target() {
   local arg="$1"
   if [[ -f "$arg" ]]; then

--- a/dot-claude-global/vault/bin/decrypt-session
+++ b/dot-claude-global/vault/bin/decrypt-session
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Decrypt one or more .age Claude Code session artifacts.
+# Fetches the age identity from the private GH vault repo on demand.
+#
+# Usage:
+#   decrypt-session <session-id>
+#   decrypt-session /path/to/file.jsonl.age
+#   decrypt-session <session-id-or-path> [<more>...]
+#
+# Identity retrieval requires `gh auth status` to be healthy.
+
+set -euo pipefail
+
+VAULT_LOCAL="${CLAUDE_VAULT_LOCAL_DIR:-$HOME/.claude/vault-local}"
+CONFIG="$VAULT_LOCAL/config.sh"
+if [[ -r "$CONFIG" ]]; then
+  # shellcheck disable=SC1090
+  . "$CONFIG"
+fi
+
+VAULT_REPO="${CLAUDE_VAULT_REPO:-}"
+PROJECTS_DIR="${CLAUDE_VAULT_PROJECTS_DIR:-$HOME/.claude/projects}"
+
+if [[ -z "$VAULT_REPO" ]]; then
+  echo "claude-vault: CLAUDE_VAULT_REPO is not set. Configure it in $CONFIG (see vault/README.md)." >&2
+  exit 1
+fi
+
+if [[ $# -eq 0 ]]; then
+  echo "Usage: $(basename "$0") <session-id-or-path> [<more>...]" >&2
+  exit 1
+fi
+
+identity_tmp=$(mktemp -t claude-vault-identity.XXXXXX)
+trap 'rm -f "$identity_tmp"' EXIT
+
+if ! gh api "repos/${VAULT_REPO}/contents/identity.txt" --jq '.content' \
+     | openssl base64 -A -d > "$identity_tmp"; then
+  echo "Failed to fetch identity from ${VAULT_REPO}. Check gh auth and repo access." >&2
+  exit 2
+fi
+
+resolve_target() {
+  local arg="$1"
+  if [[ -f "$arg" ]]; then
+    printf '%s\n' "$arg"
+    return 0
+  fi
+  # Search by session id
+  local match
+  match=$(find "$PROJECTS_DIR" \( -name "${arg}.jsonl.age" -o -name "${arg}.txt.age" \) -type f -print -quit)
+  if [[ -n "$match" ]]; then
+    printf '%s\n' "$match"
+    return 0
+  fi
+  return 1
+}
+
+status=0
+for arg in "$@"; do
+  if ! target=$(resolve_target "$arg"); then
+    echo "Not found: $arg" >&2
+    status=1
+    continue
+  fi
+
+  out="${target%.age}"
+  if [[ -e "$out" ]]; then
+    echo "Plaintext already exists, refusing to overwrite: $out" >&2
+    status=1
+    continue
+  fi
+
+  if age -d -i "$identity_tmp" -o "$out" "$target"; then
+    echo "Decrypted: $out"
+  else
+    echo "Decrypt failed: $target" >&2
+    status=1
+  fi
+done
+
+exit "$status"

--- a/dot-claude-global/vault/bin/decrypt-session
+++ b/dot-claude-global/vault/bin/decrypt-session
@@ -3,29 +3,27 @@
 # Fetches the age identity from the private GH vault repo on demand.
 #
 # Usage:
-#   decrypt-session <session-id>
-#   decrypt-session /path/to/file.jsonl.age
-#   decrypt-session <session-id-or-path> [<more>...]
-#   decrypt-session --stdout <session-id-or-path> [<more>...]
+#   decrypt-session <session-id-or-path> [<more>...]            # -> stdout
+#   decrypt-session --write <session-id-or-path> [<more>...]    # -> alongside
 #
-# With --stdout, plaintext is piped to stdout and never written to disk —
-# use this for search/inspection workflows that shouldn't leave decrypted
-# copies alongside the .age files (pipe directly into grep/jq/etc).
+# By default, plaintext is piped to stdout and never written to disk —
+# pipe directly into grep/jq/less for search and inspection. This is the
+# safe default because it leaves no decrypted copies behind.
 #
-# Without --stdout, plaintext is written alongside the .age file and its
-# mtime is set to match the .age. On the next SessionStart the encrypt
-# hook treats the matching-mtime plaintext as a stale fresh-decrypt and
-# removes it; if you edit the plaintext (bumping mtime past the .age),
-# it gets re-encrypted instead.
+# Pass --write to restore plaintext alongside the .age file (for example,
+# to un-archive a session for `claude --resume`). The plaintext mtime is
+# set to match the .age so the encrypt hook can tell "fresh decrypt"
+# (mtimes equal -> drop) from "edited after decrypt" (plaintext newer ->
+# re-encrypt) on the next SessionStart.
 #
 # Identity retrieval requires `gh auth status` to be healthy.
 
 set -euo pipefail
 
-STDOUT_MODE=0
+WRITE_MODE=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --stdout) STDOUT_MODE=1; shift ;;
+    --write) WRITE_MODE=1; shift ;;
     --) shift; break ;;
     --*) echo "Unknown flag: $1" >&2; exit 1 ;;
     *) break ;;
@@ -48,7 +46,7 @@ if [[ -z "$VAULT_REPO" ]]; then
 fi
 
 if [[ $# -eq 0 ]]; then
-  echo "Usage: $(basename "$0") [--stdout] <session-id-or-path> [<more>...]" >&2
+  echo "Usage: $(basename "$0") [--write] <session-id-or-path> [<more>...]" >&2
   exit 1
 fi
 
@@ -85,7 +83,7 @@ for arg in "$@"; do
     continue
   fi
 
-  if [[ "$STDOUT_MODE" == "1" ]]; then
+  if [[ "$WRITE_MODE" == "0" ]]; then
     if ! age -d -i "$identity_tmp" "$target"; then
       echo "Decrypt failed: $target" >&2
       status=1

--- a/dot-claude-global/vault/bin/encrypt-old-sessions
+++ b/dot-claude-global/vault/bin/encrypt-old-sessions
@@ -54,18 +54,85 @@ if ! mkdir "$LOCK_DIR" 2>/dev/null; then
   log "another run is active (lock at $LOCK_DIR) — skipping"
   exit 0
 fi
-trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
 
-encrypted=0; skipped=0; failed=0; considered=0
+# Reference file whose mtime is exactly CUTOFF_DAYS ago — lets the main loop
+# test "file older than cutoff" with bash's built-in -ot operator, avoiding
+# a find fork per candidate.
+CUTOFF_REF=$(mktemp -t claude-vault-cutoff.XXXXXX)
+if date -u -v-1d +%Y >/dev/null 2>&1; then
+  cutoff_stamp=$(date -u -v-"${CUTOFF_DAYS}"d +%Y%m%d%H%M.%S)
+else
+  cutoff_stamp=$(date -u -d "${CUTOFF_DAYS} days ago" +%Y%m%d%H%M.%S)
+fi
+touch -t "$cutoff_stamp" "$CUTOFF_REF"
+
+trap 'rmdir "$LOCK_DIR" 2>/dev/null || true; rm -f -- "${CUTOFF_REF:-}"' EXIT
+
+# Encrypt src -> dst via tmp + atomic rename. Removes src only after the .age
+# is safely in place; on any failure, the existing dst (if any) is preserved
+# and the tmp is cleaned up. Logs under $ok_label on success, $fail_label on
+# encrypt failure, and $fail_label_mv_failed on the rare mv failure path.
+encrypt_to() {
+  local src="$1" dst="$2" ok_label="$3" fail_label="$4"
+  local tmp="${dst}.tmp.$$"
+  if age -r "$RECIPIENT" -o "$tmp" "$src" 2>>"$LOG_FILE" && [[ -s "$tmp" ]]; then
+    if mv -f -- "$tmp" "$dst"; then
+      rm -f -- "$src"
+      log "${ok_label}: $src -> $dst"
+      return 0
+    fi
+    rm -f -- "$tmp"
+    log "${fail_label}_mv_failed: $src"
+    return 1
+  fi
+  rm -f -- "$tmp"
+  log "${fail_label}: $src"
+  return 1
+}
+
+encrypted=0; skipped=0; failed=0; considered=0; reconciled=0
 
 # Process substitution keeps the while-loop in the parent shell so counter
 # updates persist (bash 3.2 on macOS has no mapfile).
+#
+# The find command picks up all candidate plaintext files regardless of age;
+# the cutoff check is applied inline so we can still reconcile recent
+# both-exist cases left behind by decrypt-session.
 while IFS= read -r -d '' file; do
   considered=$((considered + 1))
   out="${file}.age"
 
   if [[ -e "$out" ]]; then
-    log "skip_existing_age: $file"
+    # Plaintext and .age both exist. Use mtime to decide authority:
+    #   plaintext strictly newer  -> treat as edited content, re-encrypt
+    #   otherwise                 -> treat as stale decrypt artifact, drop it
+    if [[ "$file" -nt "$out" ]]; then
+      if [[ "$DRY_RUN" == "1" ]]; then
+        log "dry_run_would_reencrypt: $file"
+        reconciled=$((reconciled + 1))
+        continue
+      fi
+      if encrypt_to "$file" "$out" "reencrypted" "reencrypt_failed"; then
+        reconciled=$((reconciled + 1))
+      else
+        failed=$((failed + 1))
+      fi
+    else
+      if [[ "$DRY_RUN" == "1" ]]; then
+        log "dry_run_would_drop_stale_plaintext: $file"
+        reconciled=$((reconciled + 1))
+        continue
+      fi
+      rm -f -- "$file"
+      log "dropped_stale_plaintext: $file"
+      reconciled=$((reconciled + 1))
+    fi
+    continue
+  fi
+
+  # Only plaintext exists. Encrypt if it's older than the cutoff; leave
+  # active sessions alone.
+  if [[ ! "$file" -ot "$CUTOFF_REF" ]]; then
     skipped=$((skipped + 1))
     continue
   fi
@@ -76,25 +143,15 @@ while IFS= read -r -d '' file; do
     continue
   fi
 
-  if age -r "$RECIPIENT" -o "$out" "$file" 2>>"$LOG_FILE"; then
-    if [[ -s "$out" ]]; then
-      rm -f -- "$file"
-      log "ok: $file -> $out"
-      encrypted=$((encrypted + 1))
-    else
-      rm -f -- "$out"
-      log "empty_output_aborted: $file"
-      failed=$((failed + 1))
-    fi
+  if encrypt_to "$file" "$out" "ok" "encrypt_failed"; then
+    encrypted=$((encrypted + 1))
   else
-    rm -f -- "$out"
-    log "encrypt_failed: $file"
     failed=$((failed + 1))
   fi
 done < <(
   find "$PROJECTS_DIR" \
     \( -name '*.jsonl' -o \( -path '*/tool-results/*' -name '*.txt' \) \) \
-    -type f -mtime +"$CUTOFF_DAYS" -print0
+    -type f -print0
 )
 
-log "done considered=$considered encrypted=$encrypted skipped=$skipped failed=$failed"
+log "done considered=$considered encrypted=$encrypted reconciled=$reconciled skipped=$skipped failed=$failed"

--- a/dot-claude-global/vault/bin/encrypt-old-sessions
+++ b/dot-claude-global/vault/bin/encrypt-old-sessions
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Encrypt Claude Code transcript files older than $CUTOFF_DAYS in place.
+# Non-interactive: uses the age public recipient configured in vault-local.
+# Safe to run from SessionStart (idempotent, async-friendly).
+#
+# Setup instructions: see the sibling README.md.
+
+set -euo pipefail
+
+VAULT_LOCAL="${CLAUDE_VAULT_LOCAL_DIR:-$HOME/.claude/vault-local}"
+CONFIG="$VAULT_LOCAL/config.sh"
+
+if [[ ! -r "$CONFIG" ]]; then
+  # No local config — user hasn't set up their own keypair yet.
+  # Exit 0 so SessionStart doesn't fail the session; hint to stderr.
+  echo "claude-vault: no local config at $CONFIG — encryption skipped. See vault/README.md for setup." >&2
+  exit 0
+fi
+
+# shellcheck disable=SC1090
+. "$CONFIG"
+
+CUTOFF_DAYS="${CLAUDE_VAULT_CUTOFF_DAYS:-21}"
+PROJECTS_DIR="${CLAUDE_VAULT_PROJECTS_DIR:-$HOME/.claude/projects}"
+RECIPIENT_FILE="${CLAUDE_VAULT_RECIPIENT:-$VAULT_LOCAL/recipient.txt}"
+LOG_FILE="${CLAUDE_VAULT_LOG:-$VAULT_LOCAL/encrypt.log}"
+DRY_RUN="${CLAUDE_VAULT_DRY_RUN:-0}"
+
+if [[ ! -r "$RECIPIENT_FILE" ]]; then
+  echo "claude-vault: recipient file missing or unreadable: $RECIPIENT_FILE" >&2
+  exit 1
+fi
+RECIPIENT=$(< "$RECIPIENT_FILE")
+if [[ -z "$RECIPIENT" ]]; then
+  echo "Recipient file is empty: $RECIPIENT_FILE" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "$LOG_FILE"; }
+
+log "start cutoff=${CUTOFF_DAYS}d dry_run=${DRY_RUN}"
+
+# Serialize concurrent runs (two Claude Code sessions starting in parallel can
+# otherwise race on the same file: both see plaintext exists + .age doesn't,
+# both spawn age -o, age truncates on open so the second writer corrupts the
+# first, then both pass the -s non-empty check and rm the plaintext). mkdir is
+# atomic on POSIX, so the first process that creates $LOCK_DIR wins; others
+# exit cleanly. If a previous run crashed mid-sweep, the lock dir persists —
+# delete $LOCK_DIR manually to clear.
+LOCK_DIR="$VAULT_LOCAL/encrypt.lock"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  log "another run is active (lock at $LOCK_DIR) — skipping"
+  exit 0
+fi
+trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
+
+encrypted=0; skipped=0; failed=0; considered=0
+
+# Process substitution keeps the while-loop in the parent shell so counter
+# updates persist (bash 3.2 on macOS has no mapfile).
+while IFS= read -r -d '' file; do
+  considered=$((considered + 1))
+  out="${file}.age"
+
+  if [[ -e "$out" ]]; then
+    log "skip_existing_age: $file"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    log "dry_run_would_encrypt: $file"
+    encrypted=$((encrypted + 1))
+    continue
+  fi
+
+  if age -r "$RECIPIENT" -o "$out" "$file" 2>>"$LOG_FILE"; then
+    if [[ -s "$out" ]]; then
+      rm -f -- "$file"
+      log "ok: $file -> $out"
+      encrypted=$((encrypted + 1))
+    else
+      rm -f -- "$out"
+      log "empty_output_aborted: $file"
+      failed=$((failed + 1))
+    fi
+  else
+    rm -f -- "$out"
+    log "encrypt_failed: $file"
+    failed=$((failed + 1))
+  fi
+done < <(
+  find "$PROJECTS_DIR" \
+    \( -name '*.jsonl' -o \( -path '*/tool-results/*' -name '*.txt' \) \) \
+    -type f -mtime +"$CUTOFF_DAYS" -print0
+)
+
+log "done considered=$considered encrypted=$encrypted skipped=$skipped failed=$failed"

--- a/skills/review-pr/skill.md
+++ b/skills/review-pr/skill.md
@@ -35,14 +35,16 @@ The argument is a PR number (e.g., `1172`) or a GitHub PR URL. If a URL, extract
 ### 1. Fetch PR metadata and diff
 
 ```bash
-gh pr view <number> --json title,body,baseRefName,headRefName,additions,deletions,files
+gh pr view <number> --json title,body,baseRefName,headRefName,additions,deletions,files,author
 gh pr diff <number> > /tmp/pr-<number>.diff
 gh pr diff <number> --name-only
 ```
 
 Report to the user: PR title, base/head branches, size (additions/deletions), and file count. If the PR is very large (>5000 additions), warn the user it may take a while.
 
-Check if this PR is part of a stack (base branch is not `main`/`master`/`develop`). If so, note this — some patterns in the code may come from the base branch rather than this PR. The agents should focus on what this PR changes, not what the base branch already had.
+Check if this PR is part of a stack (base branch is not `main`/`master`/`develop`). If so:
+- Note this for the agents — some patterns in the code may come from the base branch rather than this PR. The agents should focus on what this PR changes, not what the base branch already had.
+- **Map the PR chain.** Use `gh pr list --head <headRefName>` and `gh pr list --base <headRefName>` to find downstream PRs that build on this one. For each PR number in the chain, fetch its head via `git fetch origin refs/pull/<n>/head:pr/<n>` — this works uniformly whether the PR head lives in the base repo or in a fork, because GitHub exposes `refs/pull/<n>/head` on the base repo for every PR. Record the chain (e.g., "#1172 -> #1174 -> #1175 -> #1181") for reference. This is critical because stacked PRs often introduce functions in one PR and wire them up in the next — a function with zero callers in the current PR may have callers in the next PR in the chain.
 
 Infer domain context from the PR title, body, and file paths. Before launching agents, add a one-line domain summary to the shared context (e.g., "This is a blockchain indexing agent that manages on-chain allocations and payment collection" or "This is a REST API for user management"). This helps agents assess severity more accurately — knowing that "collect" means "call a smart contract" changes how you evaluate error handling.
 
@@ -70,6 +72,9 @@ Severity rules — these determine whether your review is useful or noise:
 BEFORE reporting any finding:
 1. Check callers. Search for who calls the function/method. If zero callers,
    it's dead code — report it as "dead code" under Minor, not as a bug.
+   IMPORTANT: For stacked PRs, zero callers in the current checkout does NOT
+   mean dead code. The caller may be in a downstream PR. Flag it as "no
+   callers in this PR — may be wired up downstream" rather than "dead code."
 2. Check runtime reachability. Trace the code path from an entry point (API
    handler, timer, reconciliation loop) to the flagged code. If you can't
    trace a path, the code may not execute.
@@ -145,11 +150,13 @@ After all 6 agents complete, merge their findings into a single list. Deduplicat
 
 Go through every finding ranked Significant or above and personally verify it:
 
-1. **Read the actual code** at the file and line cited.
-2. **Search for callers** — `grep` for the function name. If zero callers, downgrade to Minor (dead code).
-3. **Trace the entry point** — can you get from a timer, API handler, or user action to this code? If not, downgrade.
-4. **Check external guards** — for on-chain interactions, does the contract prevent the bad outcome? If yes, downgrade.
-5. **Ask "so what?"** — if this bug fires in production, what actually happens? If the answer is "a log line" or "wasted gas" or "a retry", it's not Significant.
+1. **Verify attribution** — if a finding claims something is "new," "introduced by," or "added in" this PR, check the diff. If the code predates this PR, correct the attribution. Observations about unchanged code are valid findings but must be labeled accurately — don't claim the PR introduced something it didn't.
+2. **Read the actual code** at the file and line cited. IMPORTANT: Use `gh pr diff <n>` when you only need the change, or fetch the PR's head ref via `git fetch origin refs/pull/<n>/head:pr/<n>` and then `git show pr/<n>:path/to/file` when you need surrounding context. This works for same-repo and forked PRs. Never use bare branch names — local branches may have extra commits from the user or other contributors that aren't part of the PR. `origin/<branch>` refs only work when the PR head lives in the base repo; for forks, the branch isn't on `origin` and you'll get a confusing error or silently read the wrong tree.
+3. **Search for callers** — `grep` for the function name. If zero callers in the current checkout, and this is a stacked PR, **fetch and search the downstream PR refs** identified in Step 1 (after `git fetch origin refs/pull/<n>/head:pr/<n>`, use `git show pr/<n>:<file> | grep <function>`). A function introduced in PR N with zero local callers but called in PR N+1 is not dead code — it's staged for the next PR. Downgrade to Minor ("dead code") only after confirming zero callers across the entire chain.
+4. **Trace the entry point** — can you get from a timer, API handler, or user action to this code? If not, downgrade.
+5. **Trace the consumer** — for "wrong data returned" findings (missing filter, wrong query, stale cache), don't stop at "this could return the wrong record." Check what the caller does with the result. Does the caller branch on it? Is the result used in a path that's actually reachable given normal control flow? A query that could match the wrong row but whose result is never used in the relevant code path is Minor at most.
+6. **Check external guards** — for on-chain interactions, does the contract prevent the bad outcome? If yes, downgrade.
+7. **Ask "so what?"** — if this bug fires in production, what actually happens? If the answer is "a log line" or "wasted gas" or "a retry", it's not Significant.
 
 Be aggressive about downgrading. A finding that "sounds scary" but can't cause harm in practice is noise. Presenting noise erodes the user's trust in the review.
 
@@ -190,6 +197,7 @@ Structure:
 # PR #<number> Review: <title>
 
 **PR**: <url>
+**Author**: <author>
 **Branch**: <head> -> <base>
 **Size**: <additions> additions, <deletions> deletions, <file_count> files
 **Reviewed**: <date>
@@ -199,11 +207,17 @@ Structure:
 
 ## Significant
 ### <N>. <Title>
-<Description with entry point, trigger, and consequence.>
+**In short**: <1-2 sentence non-technical summary of what's wrong and what to do about it. No function names or code — write it so someone skimming the review gets the point immediately.>
+<Description with entry point, trigger, and consequence. When a finding involves multiple steps or behavior over time, include a short concrete example showing what happens rather than describing the problem abstractly. Use tables to show state (e.g., DB rows before/after, cache entries, queue items) — visual reporting is easier to follow than prose for stateful bugs.>
+**Fix**: <Concrete recommendation — what to change, where, and why. If there are multiple options, list them with trade-offs.>
 **Status**: [ ] Reviewed
 
 ## Moderate
-...
+### <N>. <Title>
+**In short**: <1-2 sentence non-technical summary.>
+<Description.>
+**Fix**: <Concrete recommendation.>
+**Status**: [ ] Reviewed
 
 ## Minor
 ...


### PR DESCRIPTION
## Motivation

Claude Code writes session transcripts to `~/.claude/projects/*.jsonl` in plaintext with configurable retention. This adds an at-rest encryption layer for older transcripts: `age`-encrypt anything older than 21 days on each session start, keep recent sessions plaintext for resumption.

Once the vault was in use, a second problem surfaced. Searching the encrypted archive (for example, to locate an old conversation by keyword) required restoring plaintext via `decrypt-session`, and those plaintext files then lingered forever: the original `encrypt-old-sessions` explicitly skipped any `.jsonl` whose `.age` twin already existed, so a single decrypt-for-search workflow permanently defeated the vault for those sessions unless the user remembered to delete the plaintext by hand. Follow-on commits close that gap end-to-end.

## Summary

- New `dot-claude-global/vault/` with generic scripts:
  - `bin/encrypt-old-sessions` — non-interactive. Sweeps `.jsonl` and `tool-results/*.txt`, encrypts anything older than `CLAUDE_VAULT_CUTOFF_DAYS` (default 21), deletes plaintext after verifying the ciphertext is non-empty. Reconciles the both-exist case on every run: plaintext strictly newer than its `.age` twin is re-encrypted (capturing resumed-session writes or manual edits), otherwise the stale plaintext is dropped and the existing `.age` is preserved.
  - `bin/decrypt-session` — on-demand. Fetches the `age` identity from a user-configured private GH repo, decrypts one or more files or session ids. Plaintext pipes to stdout by default so search and inspection workflows leave nothing behind; pass `--write` to restore plaintext alongside the `.age` for un-archiving a session. When running interactively against a TTY, a one-line hint on stderr reminds the caller that `--write` is how you save to disk. Pipes and redirects stay silent.
  - `README.md` — setup guide (bring your own age keypair and private vault repo; personal config lives outside this repo).
- Personal config stays outside this public repo at `~/.claude/vault-local/{recipient.txt,config.sh,encrypt.log}`. The scripts source `config.sh` at runtime and exit gracefully when it is missing, so cloning this repo does not silently encrypt anyone else's transcripts.
- Fresh-encrypt and re-encrypt share one atomic write path: both produce a `${dst}.tmp.$$` and `mv` it into place only after verifying non-empty output, so a crash mid-encryption cannot leave a half-baked `.age` readable from the final path. The rare `mv` failure cleans up the tmp and preserves the existing `.age`.
- Mtime comparisons use bash builtins (`-nt`, `-ot`) against a precomputed cutoff reference file, avoiding a `find` fork per candidate as the archive grows to thousands of files.
- `dot-claude-global/settings.json`: wire the `SessionStart` hook (async), raise `cleanupPeriodDays` to `1460` (renamed `.age` files aren't seen by Claude Code's native cleanup anyway), persist `effortLevel` and `skipAutoPermissionPrompt`.
- `.gitignore`: ignore the runtime `encrypt.log`.
- Unrelated housekeeping already in the working tree: memory-file rule tightened in `CLAUDE.md`, `review-pr` skill improvements (stacked-PR handling, concrete-fix sections), and `_DISABLED_` prefix applied to env vars that were effectively no-ops.

First live sweep on the backlog: 2191 files / 816.5 MB encrypted in 23 seconds, 0 failures. Round-trip decrypt verified end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session transcript encryption and decryption capabilities for enhanced privacy and data retention.

* **Chores**
  * Updated system configuration settings including effort level optimization, cleanup periods, and scrolling behavior.
  * Improved internal memory management rules for safer operations.
  * Enhanced PR review documentation with refined verification workflows and additional metadata tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->