### PR TITLE
docs: expand PR motivation guidance with stakes and cold-reader rule

### DIFF
--- a/dot-claude-global/CLAUDE.md
+++ b/dot-claude-global/CLAUDE.md
@@ -30,11 +30,13 @@
 
 ### Motivation section
 
-The motivation orients the reader before they look at any code. Write it as if explaining to yourself on a day you haven't touched this area — clear enough to anchor what the PR does and why, without needing to read the diff first.
+The motivation orients the reader before they look at any code. Write it for two audiences at once: yourself on a day you haven't touched this area, and a colleague landing on the PR cold — no prior context on the change, the surrounding code, or sibling PRs in a stacked series. Both should understand the point without reading the diff, related PRs, or external docs.
 
 **Structure**: Open with what the system does today (the normal behaviour or current state), then introduce what's wrong or missing, then connect that to the impact. The reader should understand the "before" picture before seeing the "after."
 
-**Tone**: Use the natural domain language of the project (contracts, escrow, receipts, signers) but avoid implementation internals (actor mailboxes, HashMap semantics, trait impls). If a term wouldn't come up in a conversation about what the system does — only in how the code works — it belongs in the summary or code comments, not the motivation. Don't overstate the impact or make unverified claims — if something "may" cause an issue, say "may."
+**Stakes**: Make the cost of the status quo explicit. Who is hurt by the current state — users, operators, on-call, future maintainers? What breaks, gets missed, or gets harder if this PR doesn't land? A motivation that ends at "X causes Y" without answering "and so what?" leaves the reader unable to judge how much the PR matters. Stakes should be concrete (named systems, named consequences), not vague gestures like "this is bad for users."
+
+**Tone**: Write at a level a non-engineer collaborator (PM, designer, a reviewer of your work who isn't deep in this codebase) could follow. Use the natural domain language of the project (contracts, escrow, receipts, signers) but avoid implementation internals (actor mailboxes, HashMap semantics, trait impls). If a term wouldn't come up in a conversation about what the system does — only in how the code works — it belongs in the summary or code comments, not the motivation. When a domain term is unavoidable but likely opaque to a non-technical reader, gloss it in one short clause the first time it appears. Don't overstate the impact or make unverified claims — if something "may" cause an issue, say "may."
 
 **Specificity**: Name the actual components and services involved. "The network subgraph" not "a subgraph." Vague references force the reader to guess.
 


### PR DESCRIPTION
## Motivation

The global PR body guidance in `dot-claude-global/CLAUDE.md` tells Claude to write a Motivation section before the summary, with rules covering structure (before/after framing), tone (domain language over implementation jargon), specificity, and cause-and-effect narrative. In practice this gets a reviewer most of the way to understanding what a PR does.

It leaves gaps, though, when the reviewer wants a deep, non-technical understanding of *why* the PR matters. The guidance asks the writer to "connect to the impact" but never to name the cost of the status quo, so a motivation can technically comply by tracing "X causes Y" without ever answering "and so what?". It only requires writing "for yourself on a day you haven't touched this area" — not for a reviewer who has never seen the code, which lets standalone framing slip in stacked PR series. And "domain language" is permitted to mean dense technical jargon (escrow, signers, receipts), which excludes non-engineer reviewers.

The result is that a PR can satisfy every existing rule and still leave a reviewer unsure who is hurt by the current state or whether the change matters at all — pushing reviews toward code-correctness checks rather than judgments about whether the change is the right one to make.

## Summary

- Reframe Motivation audience: write for both your future self and a colleague landing cold with no prior context on the change, surrounding code, or sibling PRs in a stack
- Add **Stakes** subsection: name who is hurt by the status quo (users, operators, on-call, future maintainers) and what concretely breaks if the PR does not land
- Rewrite **Tone**: write at a level a non-engineer collaborator could follow; gloss unavoidable domain terms in one short clause on first use

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal contribution guidelines to enhance clarity and accessibility for PR reviewers across all roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->