### PR TITLE
fix: stop showing raw JSON in the effort line of the statusline

### DIFF
--- a/dot-claude-global/statusline.sh
+++ b/dot-claude-global/statusline.sh
@@ -250,7 +250,7 @@ effort_level=""
 
 # 1. Statusline JSON input (future-proof if Anthropic adds it)
 if [ "$HAS_JQ" -eq 1 ]; then
-  effort_level=$(echo "$input" | jq -r '.effort // empty' 2>/dev/null)
+  effort_level=$(echo "$input" | jq -r 'if (.effort | type) == "object" then (.effort.level // empty) else (.effort // empty) end' 2>/dev/null)
 fi
 
 # 2. Parse session JSONL for most recent effort change (~26ms)
@@ -276,7 +276,7 @@ for line in sys.stdin:
     except: pass
 print(effort)
 " 2>/dev/null)
-  case "$effort_level" in low|medium|high|max|auto) ;; *) effort_level="" ;; esac
+  case "$effort_level" in low|medium|high|xhigh|max|auto) ;; *) effort_level="" ;; esac
 fi
 
 # 3. Read configured default from settings.json


### PR DESCRIPTION
## TL;DR

The statusline was rendering the effort indicator as a three-line JSON blob (`{"level": "xhigh"}`) instead of a one-word label. This PR extracts the level string so the statusline reads `xhigh` again. Safe to approve — one-line shell change, no behavioural impact beyond the visible fix.

## Motivation

The statusline is the small panel under the prompt that summarises directory, model, context usage, and the current effort level. Until recently Claude Code sent the effort level as a plain string (`"max"`, `"high"`, etc.) on the JSON blob piped to the statusline script, and the script printed it verbatim. Claude Code has since changed that field to an object of the form `{"level": "xhigh"}`, and the existing `jq -r '.effort'` extractor on an object emits pretty-printed JSON rather than a string.

The visible result is that the effort line in every session now shows a three-line JSON blob in place of the label, which is noisy on every prompt and makes the rest of the panel harder to scan. Nothing is broken functionally, but the panel exists to be glanceable, so the regression directly undercuts its purpose for anyone using a recent Claude Code build.

## Summary

- Pull `.effort.level` when the field is an object, fall back to the bare string for older payloads.
- Add `xhigh` to the JSONL-path validation allowlist so it is not silently dropped.