### PR TITLE
docs: tighten global rules and review-todo formatting

### DIFF
--- a/dot-claude-global/CLAUDE.md
+++ b/dot-claude-global/CLAUDE.md
@@ -30,8 +30,7 @@
 ### Commit Messages
 
 - Title: conventional commit format `type(scope): subject`, under 72 characters. Scope is required: exactly 1 word, no hyphens or slashes, specific enough to point at the right area, scope should not be ambiguous.
-- Body: 1-4 lines max, wrap at 72 characters. State what the commit *does* and *why*, not a full essay. Save detailed context for the PR body. If the change can't be explained in 4 lines, split it into multiple commits.
-- Build the body from context to action: open with the situation (what exists, what's broken or missing), then describe what the commit changes. Each sentence should set up the next, so a reader without prior context — think 3 a.m., unfamiliar repo — can follow without needing to look anything up.
+- Body: as short as the change allows, up to 4 lines, wrapped at 72 characters. The test for whether a body is good is whether someone who doesn't read the codebase (or even the language) could read it and explain to a third person, in their own words, what the commit does and why. For trivial mechanical fixes a single sentence is often enough. When the title alone wouldn't let a non-engineer reason about the change, build the body from context to action — open with the situation (what exists, what's broken or missing), then describe the change. If the change can't be explained in 4 lines, split it into multiple commits.
 - Trailers (e.g. `Co-Authored-By:`) live below a blank line after the body and don't count against the 4-line limit
 - Never restate the title in the body
 

--- a/dot-claude-global/CLAUDE.md
+++ b/dot-claude-global/CLAUDE.md
@@ -8,6 +8,7 @@
 
 ## Rules
 
+- **Never merge or land a PR unless I have explicitly told you to in the current turn.** Never assume a PR is approved when I have not approved it. This applies to `gh pr merge`, the `/land-pr` skill, squash/rebase/merge commits, auto-merge flags, and any equivalent action. If you think a PR is ready, say so and wait — do not merge.
 - Every fix should address the immediate symptom and the underlying pattern — make the system robust against the same class of issue recurring
 - Never use emojis
 - Markdown documents, where possible, should read like a narrative, not a checklist

--- a/skills/review-todo/SKILL.md
+++ b/skills/review-todo/SKILL.md
@@ -27,7 +27,7 @@ Group items into three sections, in this order, each as a bold top-level heading
 
 Decisions go first so the user can answer the questions in one pass, then work straight through the rest. If a section has no items, omit the heading entirely rather than leave it empty.
 
-Number items continuously across sections (1, 2, 3, … — do not restart at each heading). Within each section, keep the review's original order. One short sentence per item description, soft cap of about 20 words. **Fixes** and **Polish** items are description-only — no sub-bullets, no nesting. **Decisions needed** items carry an additional `→ Question?` block (and optionally lettered choices) below the description, as detailed in the next section. No preamble before the first heading, no closing remarks.
+Number items continuously across sections (1, 2, 3, … — do not restart at each heading), and bold the number marker so each item reads as its own sub-heading (`**1.**`, `**2.**`, …). The bold applies only to the marker — the description, the `→` line, and the lettered choices stay in regular weight. Separate every item from the next with a blank line. This matters most when a decision item's lettered choices end immediately before the following item's description: without a blank line the two collide visually and the eye loses the boundary. Within each section, keep the review's original order. One short sentence per item description, soft cap of about 20 words. **Fixes** and **Polish** items are description-only — no sub-bullets, no nesting. **Decisions needed** items carry an additional `→ Question?` block (and optionally lettered choices) below the description, as detailed in the next section. No preamble before the first heading, no closing remarks.
 
 **Lead each item with prose, not metadata.** The first few words are what the user's eye lands on when skimming, so they should describe the problem, not the location. Start with a natural article or verb — "The retry loop…", "Each source file…", "Add a test…" — never with a bare file path or a bare noun phrase. "Retry loop has no cap" is one word away from "The retry loop has no cap" and the second is meaningfully easier to read.
 
@@ -35,12 +35,16 @@ Number items continuously across sections (1, 2, 3, … — do not restart at ea
 
 ```
 **Fixes**
-3. Add a test for the `--dry-run --daemon` combo so a future guard change can't silently break it (compact.py).
-4. The `safe=False` cast invariant is only doc-pinned — add a guard or test that fails if a non-null promotion path is added (compact.py:`_resolve_field_type`).
+
+**3.** Add a test for the `--dry-run --daemon` combo so a future guard change can't silently break it (compact.py).
+
+**4.** The `safe=False` cast invariant is only doc-pinned — add a guard or test that fails if a non-null promotion path is added (compact.py:`_resolve_field_type`).
 
 **Polish**
-6. Each source file is opened twice (schema read, then table read) — cache schemas if first-backfill latency matters (compact.py:`_unify_schemas`).
-7. The verify step trusts non-timestamp columns blindly — only timestamp min/max round-trips (compact.py:`_verify_compacted`).
+
+**6.** Each source file is opened twice (schema read, then table read) — cache schemas if first-backfill latency matters (compact.py:`_unify_schemas`).
+
+**7.** The verify step trusts non-timestamp columns blindly — only timestamp min/max round-trips (compact.py:`_verify_compacted`).
 ```
 
 ## Items that need a decision before they can be fixed
@@ -53,20 +57,21 @@ When the reviewer named two or more discrete alternatives, list them as lettered
 
 ```
 **Decisions needed**
-1. The retry loop has no cap or escalation — one bad date logs WARNING hourly forever (compact.py:`_run_sweep_safely`).
+
+**1.** The retry loop has no cap or escalation — one bad date logs WARNING hourly forever (compact.py:`_run_sweep_safely`).
 
    → Cap with backoff, escalate to ERROR for ntfy, or quarantine the bad date?
      a. cap retries with exponential backoff  *(recommended)*
      b. escalate to ERROR and route to ntfy
      c. quarantine the bad date and continue
 
-2. The compactor's 4 AM ET wake-up time is documented in three places (compact.py + docker-compose.yml + SKILL.md).
+**2.** The compactor's 4 AM ET wake-up time is documented in three places (compact.py + docker-compose.yml + SKILL.md).
 
    → Pass `--target-hour` from compose for a single source of truth, or accept the duplication?
      a. plumb `--target-hour` through compose
      b. accept the duplication and add a comment in each place
 
-3. The new `GRT_MIN_STAKE` env var landed in the gateway config but reviewer thinks it's misplaced (config/gateway.yaml:31).
+**3.** The new `GRT_MIN_STAKE` env var landed in the gateway config but reviewer thinks it's misplaced (config/gateway.yaml:31).
 
    → Which service owns this setting?
 ```
@@ -82,6 +87,8 @@ A finding where the reviewer already recommended a specific fix is *not* a decis
 - Do not lead an item with a file path or a bare noun. Add a natural article or verb so the eye lands on the problem.
 - Do not inline the question on the same line as the item description — drop to a new line and lead with `→ `.
 - Do not number the lettered choices (`1.`, `2.`) — use letters (`a.`, `b.`) so they cannot be confused with the parent item number.
+- Do not omit the bold on a number marker — every numbered item leads with `**N.**`. The lettered choices stay in regular weight; only the parent marker is bolded.
+- Do not pack items together without a blank line between them. A decision item whose lettered choices end immediately before the next item's description is the most common offender — leave a blank line before the next `**N.**`.
 
 ## Edge cases
 


### PR DESCRIPTION
## TL;DR

Three small guidance fixes to the global Claude config: a hard rule against landing PRs without explicit approval, a rewrite of the commit-body rule so trivial fixes stop getting four-line bodies, and a formatting tweak to the review-todo skill so each item reads as its own sub-heading.

## Motivation

The global config in `dot-claude-global` is the prompt the assistant reads on every session, so the rules in it shape how it writes commits, drives PR workflows, and renders skill output. Three rough edges had accumulated: the assistant sometimes treated an open ready PR as authority to merge it, the "1-4 lines max" commit-body rule paired with a structural context-then-action rule kept pushing trivial fixes to four lines of filler, and review-todo output let lettered choices on a decision item blur straight into the next item's description because there was no enforced blank line. The first risks landing work that has not yet been reviewed, the second wastes commit bodies on padding that crowds out genuinely meaningful ones, and the third makes review-feedback triage harder than it needs to be. Each is a small fix on its own, but they all live in the same global config, so it is cheaper to land them together than to stack three separate one-line PRs. The combined effect is an assistant that is safer with merges, terser on small commits, and easier to scan when triaging review output.

## Summary

- Add a rule forbidding any merge or land action without explicit approval in the current turn.
- Rewrite the commit-body rule to key on whether a non-engineer could re-explain the commit.
- Bold review-todo item markers and require a blank line between items.