### PR TITLE
chore: refine global rules and allow env access in one repo

### DIFF
--- a/dot-claude-global/CLAUDE.md
+++ b/dot-claude-global/CLAUDE.md
@@ -15,6 +15,7 @@
 - Never make unverified claims or state facts disproportionate to the truth. Surgical accuracy, not overblown hype.
 - Keep ALL data and numbers intact when rewriting or summarising.
 - Write like explaining to a colleague: use transitional phrases, keep technical detail in prose form, prefer minimalist language (e.g. "adapted" not "carefully adapted"). Avoid robotic formatting and repetitive word choices.
+- Prefer plain English over engineering jargon — write so a non-engineer collaborator (PM, designer) could follow. "Prevent X" over "gate X", "rename Y" over "alias Y", "skip when Z" over "short-circuit on Z". Applies everywhere: commit messages, PR bodies, code comments, chat replies.
 - If I ask you a question and you are not 100% sure, please let me know that you're not sure rather than stating something that could be wrong
 - When working with git operations, always confirm the current working directory before running commands, especially after subshell operations or package installs
 - When analyzing systems or services, be exhaustive — list ALL relevant components. Do not omit services unless explicitly told to scope down
@@ -30,6 +31,7 @@
 ### Commit Messages
 
 - Title: conventional commit format `type(scope): subject`, under 72 characters. Scope is required: exactly 1 word, no hyphens or slashes, specific enough to point at the right area, scope should not be ambiguous.
+- Subject after `type(scope):` reads as completing "If applied, this commit will…" — start with an imperative verb that names the specific action (extract, simplify, prevent, batch, drop, rename), not one that just restates the type (`fix(api): fix X`, `refactor(core): refactor Y`). Good: `fix(api): prevent infinite retry loop when downstream returns 429s`, `refactor(core): extract retry helper used by three near-identical callers`. Use plain English, not engineering jargon (e.g. "prevent" over "gate").
 - Body: as short as the change allows, up to 4 lines, wrapped at 72 characters. The test for whether a body is good is whether someone who doesn't read the codebase (or even the language) could read it and explain to a third person, in their own words, what the commit does and why. For trivial mechanical fixes a single sentence is often enough. When the title alone wouldn't let a non-engineer reason about the change, build the body from context to action — open with the situation (what exists, what's broken or missing), then describe the change. If the change can't be explained in 4 lines, split it into multiple commits.
 - Trailers (e.g. `Co-Authored-By:`) live below a blank line after the body and don't count against the 4-line limit
 - Never restate the title in the body
@@ -85,7 +87,7 @@ The motivation orients the reader before they look at any code. Write it for two
 
 #### Summary and Changes sections
 
-The summary is a concise list of what the PR actually does. Keep it to bullet points — the narrative belongs in the motivation, not here. Each bullet point should contain a sentence with less than 100 characters.
+The summary is a concise list of what the PR actually does. Keep it to bullet points — the narrative belongs in the motivation, not here. Each bullet point should contain a sentence with less than 100 characters. Same plain-English standard as the rest of the body — no file paths, function names, or engineering jargon.
 
 ## Memories
 

--- a/dot-claude-global/hooks/block-env-files.py
+++ b/dot-claude-global/hooks/block-env-files.py
@@ -113,6 +113,27 @@ SAFE_PATTERNS = [
     r"\.env\.template$",
 ]
 
+# Directories where .env access is explicitly allowed (user-trusted projects).
+# Only applies to file tools (Read/Write/Edit/Glob/Grep). Bash patterns stay
+# conservative across the board.
+ALLOWED_ENV_DIRS = [
+    str(Path.home() / "Documents/github/local-network"),
+]
+
+
+def path_in_allowed_env_dir(path: str) -> bool:
+    """True if the path resolves to somewhere inside an allowed-env directory."""
+    if not path:
+        return False
+    resolved = resolve_path(path) or path
+    abs_path = os.path.abspath(os.path.normpath(resolved))
+    for allowed in ALLOWED_ENV_DIRS:
+        allowed_abs = os.path.abspath(allowed)
+        if abs_path == allowed_abs or abs_path.startswith(allowed_abs + os.sep):
+            return True
+    return False
+
+
 # Commands that can read file contents
 FILE_READ_COMMANDS = [
     "cat",
@@ -226,6 +247,10 @@ def is_sensitive_file(path: str) -> bool:
     for pattern in SAFE_PATTERNS:
         if re.search(pattern, path, re.IGNORECASE):
             return False
+
+    # Allow .env access inside user-trusted project directories
+    if path_in_allowed_env_dir(path):
+        return False
 
     # Check all path variants
     resolved = resolve_path(path) or path


### PR DESCRIPTION
## TL;DR

Adds three rules to global CLAUDE.md so future commit subjects and PR summaries land verb-led and in plain English, and adds a single-folder allowlist to the block-env-files hook so the local-network compose stack's `.env` is readable by file tools. Both are documentation/config refinements with no impact on production code.

## Motivation

Recent commits across the workspace landed with subjects like `fix(dips): chain_listener drain loop, gated sweep, paginated reconcile` — readable by an engineer but noun-led, in a style where the action the commit performs isn't obvious at a glance. The current CLAUDE.md commit-message rules don't mandate verb-led imperatives or plain English, so future commits keep drifting that way. Without a fix the commit log becomes harder to skim, especially for non-engineer collaborators reviewing the PR list.

Separately, the block-env-files hook treats every `.env` file as sensitive, which is the right default for most repos but blocks legitimate file reads in `local-network`, where the `.env` is just compose-stack local config under the user's control. The new allowlist trusts that single directory for file tools while keeping the strict default — and the strict bash-command checks — everywhere else.

## Summary

- Add a top-level rule that plain English wins over engineering jargon, with examples.
- Add a commit-subject rule with two positive examples showing the expected shape.
- Add a plain-English clause on the PR Body Summary section to match TL;DR and Motivation.
- Add an `ALLOWED_ENV_DIRS` allowlist for `local-network` to the block-env-files hook.
- Bash command checks stay strict across all directories, including allowlisted ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)