### PR TITLE
fix: tighten commit-message validation

### DIFF
--- a/dot-claude-global/CLAUDE.md
+++ b/dot-claude-global/CLAUDE.md
@@ -28,6 +28,10 @@
 
 ## Git Workflow
 
+### Self-contained messages
+
+Every commit message and PR body MUST stand on its own. Readers should not need outside context — prior conversations, other commits, internal lore, codebase knowledge — to understand what the change does and why. Cross-references ("the original X bug", "after the Y refactor") are forbidden unless the surrounding context is inlined; internal jargon ("the planner picked a query shape that hid the bug", "snapshot-pinned subgraph block") must be explained in plain language or replaced. Test by reading your draft as if you'd never seen this codebase: if any sentence makes you ask "wait, what is X?", add context, rewrite, or split the change.
+
 ### Commit Messages
 
 - Title: conventional commit format `type(scope): subject`, under 72 characters. Scope is required: exactly 1 word, no hyphens or slashes, specific enough to point at the right area, scope should not be ambiguous.

--- a/dot-claude-global/hooks/test_validate_commit_message.py
+++ b/dot-claude-global/hooks/test_validate_commit_message.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Tests for validate-commit-message.py hook.
+
+Pinned focus: the hook must recognise `git commit` even when global flags
+like `-C <path>`, `-c <name>=<value>`, or `--no-pager` sit between `git`
+and `commit`. A regression where the recognition regex required the
+literal substring `git commit` allowed every commit issued via
+`git -C /path commit ...` to silently bypass validation.
+"""
+
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+HOOK_PATH = str(Path(__file__).resolve().parent / "validate-commit-message.py")
+
+
+def run_hook(command: str) -> subprocess.CompletedProcess:
+    """Invoke the hook with a Bash PreToolUse payload and given command."""
+    payload = {
+        "tool_name": "Bash",
+        "hook_event_name": "PreToolUse",
+        "tool_input": {"command": command},
+    }
+    return subprocess.run(
+        ["python3", HOOK_PATH],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+    )
+
+
+# A 6-line body — three rules' worth of content above the 4-line cap.
+# Used wherever a test wants to confirm the hook caught the body length.
+SIX_LINE_BAD_BODY = (
+    "fix(scope): too long\n\nLine 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6"
+)
+
+
+class TestGitCommitDetection(unittest.TestCase):
+    """The hook must recognise every shape of `git commit` it gets called on."""
+
+    def test_plain_git_commit_is_recognised(self):
+        proc = run_hook(f'git commit -m "{SIX_LINE_BAD_BODY}"')
+        self.assertEqual(proc.returncode, 2, proc.stderr)
+        self.assertIn("Body has 6 non-empty lines", proc.stderr)
+
+    def test_git_dash_C_is_recognised(self):
+        proc = run_hook(f'git -C /tmp/repo commit -m "{SIX_LINE_BAD_BODY}"')
+        self.assertEqual(proc.returncode, 2, proc.stderr)
+        self.assertIn("Body has 6 non-empty lines", proc.stderr)
+
+    def test_git_dash_C_absolute_path_is_recognised(self):
+        proc = run_hook(
+            f'git -C /Users/sam/Documents/github/repo commit -m "{SIX_LINE_BAD_BODY}"'
+        )
+        self.assertEqual(proc.returncode, 2, proc.stderr)
+
+    def test_git_dash_c_config_is_recognised(self):
+        proc = run_hook(f'git -c user.name=foo commit -m "{SIX_LINE_BAD_BODY}"')
+        self.assertEqual(proc.returncode, 2, proc.stderr)
+
+    def test_git_no_pager_is_recognised(self):
+        proc = run_hook(f'git --no-pager commit -m "{SIX_LINE_BAD_BODY}"')
+        self.assertEqual(proc.returncode, 2, proc.stderr)
+
+    def test_git_long_flag_with_equals_is_recognised(self):
+        proc = run_hook(f'git --git-dir=/tmp/.git commit -m "{SIX_LINE_BAD_BODY}"')
+        self.assertEqual(proc.returncode, 2, proc.stderr)
+
+    def test_git_multiple_global_flags_recognised(self):
+        proc = run_hook(
+            f'git -C /tmp --no-pager -c user.email=x commit -m "{SIX_LINE_BAD_BODY}"'
+        )
+        self.assertEqual(proc.returncode, 2, proc.stderr)
+
+    def test_chained_with_double_ampersand_recognised(self):
+        # `git add ... && git -C /path commit ...` — the form the agent
+        # actually uses. The hook splits on newline only, so the whole
+        # invocation is one line; the regex must still find `commit`.
+        proc = run_hook(
+            f'git add file && git -C /tmp/repo commit -m "{SIX_LINE_BAD_BODY}"'
+        )
+        self.assertEqual(proc.returncode, 2, proc.stderr)
+
+
+class TestNonCommitInvocations(unittest.TestCase):
+    """Anything that isn't `git commit` must pass through (exit 0)."""
+
+    def test_git_status(self):
+        proc = run_hook("git status")
+        self.assertEqual(proc.returncode, 0)
+
+    def test_git_dash_C_checkout(self):
+        proc = run_hook("git -C /tmp/repo checkout main")
+        self.assertEqual(proc.returncode, 0)
+
+    def test_git_dash_C_log(self):
+        proc = run_hook("git -C /tmp/repo log --oneline")
+        self.assertEqual(proc.returncode, 0)
+
+    def test_non_git_command(self):
+        proc = run_hook("ls -la")
+        self.assertEqual(proc.returncode, 0)
+
+    def test_amend_no_edit_passes_through(self):
+        # Reusing the prior message — nothing to validate.
+        proc = run_hook("git commit --amend --no-edit")
+        self.assertEqual(proc.returncode, 0)
+
+    def test_amend_no_edit_with_dash_C_passes_through(self):
+        proc = run_hook("git -C /tmp/repo commit --amend --no-edit")
+        self.assertEqual(proc.returncode, 0)
+
+
+class TestValidMessages(unittest.TestCase):
+    """Well-formed messages must pass."""
+
+    def test_minimal_valid_message(self):
+        proc = run_hook('git commit -m "fix(scope): do the thing"')
+        self.assertEqual(proc.returncode, 0)
+
+    def test_valid_message_with_dash_C(self):
+        proc = run_hook('git -C /tmp/repo commit -m "fix(scope): do the thing"')
+        self.assertEqual(proc.returncode, 0)
+
+    def test_valid_message_with_4_line_body(self):
+        body = "fix(scope): do the thing\n\nLine 1\nLine 2\nLine 3\nLine 4"
+        proc = run_hook(f'git -C /tmp/repo commit -m "{body}"')
+        self.assertEqual(proc.returncode, 0)
+
+
+class TestRejectionMessageQuality(unittest.TestCase):
+    """The rejection block must include CLAUDE.md reminders."""
+
+    def test_reminders_block_present_on_failure(self):
+        proc = run_hook(f'git -C /tmp/repo commit -m "{SIX_LINE_BAD_BODY}"')
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("Reminders for the rewrite", proc.stderr)
+        self.assertIn("Body stands on its own", proc.stderr)
+        self.assertIn("imperative verb", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dot-claude-global/hooks/validate-commit-message.py
+++ b/dot-claude-global/hooks/validate-commit-message.py
@@ -18,7 +18,9 @@ Coverage:
 
 Known limitations (lean-allow):
   - Pathological shell escaping or nested heredocs fall through.
-  - `git c` (alias) isn't recognised — only literal `git commit` is matched.
+  - `git c` (aliases) aren't recognised — `git commit` (with optional
+    global flags like `-C <path>`, `-c name=val`, `--no-pager`, etc.)
+    is what we match.
   - Body lines that look like trailers (`Fixes: x`) after a blank line ARE
     stripped as trailers, matching git's own trailer semantics.
 
@@ -51,6 +53,19 @@ CONVENTIONAL_TYPES = (
 )
 CONVENTIONAL_TITLE_RE = re.compile(
     r"^(" + "|".join(CONVENTIONAL_TYPES) + r")\([a-z0-9]+\)!?: .+$"
+)
+
+# Detect `git [global flags] commit`. The earlier `\bgit\s+commit\b` form
+# missed `git -C <path> commit` (and other global-flag prefixes) entirely,
+# silently letting any commit invoked that way bypass validation. Allows
+# zero or more flag tokens between `git` and `commit`:
+#   - `-C <path>` / `-c <name>=<value>`           (`-[Cc]\s+\S+`)
+#   - bundled or single-letter flags like `-p`    (`-[A-Za-z]+`)
+#   - long flags `--name`, `--name=value`         (`--[\w-]+(?:=\S+)?`)
+GIT_COMMIT_RE = re.compile(
+    r"\bgit"
+    r"(?:\s+(?:-[Cc]\s+\S+|-[A-Za-z]+|--[\w-]+(?:=\S+)?))*"
+    r"\s+commit\b"
 )
 
 # A git trailer is a `Token: value` pair where Token uses Title-Case-With-Hyphens.
@@ -218,7 +233,7 @@ def main() -> None:
     # a heredoc body (e.g. test scripts piping Python with git references)
     # would otherwise self-trigger.
     invocation = cmd.split("\n", 1)[0]
-    if not re.search(r"\bgit\s+commit\b", invocation):
+    if not GIT_COMMIT_RE.search(invocation):
         pass_through()
     # --amend --no-edit reuses the prior message; nothing to validate.
     if is_amend_no_edit(cmd):
@@ -232,7 +247,19 @@ def main() -> None:
     errors = validate(msg)
     if errors:
         bullet = "\n  - ".join(errors)
-        deny("Commit message rejected:\n  - " + bullet)
+        reminders = (
+            "\n\nReminders for the rewrite (~/.claude/CLAUDE.md):\n"
+            '  - Title reads as completing "If applied, this commit '
+            'will…" — lead with an imperative verb (extract, simplify, '
+            "prevent), not the type itself. Plain English, not jargon "
+            '("prevent" over "gate", "rename" over "alias").\n'
+            '  - Body stands on its own. No references to "the original '
+            'X bug" or "after the Y refactor" without inlining the '
+            "context; no function names or internal jargon. A reader who "
+            "has never seen this codebase should be able to follow.\n"
+            "  - Don't restate the title in the body."
+        )
+        deny("Commit message rejected:\n  - " + bullet + reminders)
 
     pass_through()
 


### PR DESCRIPTION
## TL;DR

The commit-message validation hook had a hole that let any commit issued with global git flags (e.g. `git -C /path commit`) bypass validation entirely. This PR closes the hole, pins it with tests, makes rejections more actionable, and adds a written rule that commit and PR bodies must stand on their own.

## Motivation

The pre-commit hook in `dot-claude-global/hooks/validate-commit-message.py` enforces our commit-message rules — title length, conventional format, body line count — by recognising when a Bash invocation is a `git commit`. Until now it matched the literal substring `git commit`, which meant any invocation that put global flags in front (the common `git -C /path commit ...` pattern, plus `--no-pager`, `-c name=value`, and so on) was treated as "not a commit" and waved through. Any commit produced that way landed without ever being checked, defeating the hook for the most common shape an agent uses to commit from outside a repo.

On top of that, when the hook did fire and reject a message, it returned the failures alone — a contributor (human or agent) then had to dig into the rules file to figure out the right shape for the rewrite, which made retries slow and noisy.

## Summary

- Recognise `git commit` even with global flags between `git` and `commit` (the bypass fix).
- Add a test file pinning recognition across all common `git commit` shapes plus pass-through cases.
- On rejection, append a reminders block summarising the title and body writing rules.
- Add a "self-contained messages" rule to the global Claude config covering commit and PR bodies.