### PR TITLE
fix: improve dismissal hook feedback and commit validation

### DIFF
--- a/dot-claude-global/hooks/block-preexisting-dismissal.py
+++ b/dot-claude-global/hooks/block-preexisting-dismissal.py
@@ -5,7 +5,8 @@ as "pre-existing" without fixing or flagging them.
 
 Reads the session transcript to find the last assistant message and checks
 for the word "pre-existing" (or "preexisting"). If found, blocks the stop
-and instructs Claude to address the errors.
+and quotes each offending sentence back to Claude with the trigger phrase
+highlighted, so Claude can see exactly what was flagged.
 
 Uses stop_hook_active to prevent infinite loops — if this hook already
 triggered a continuation, allow the next stop unconditionally.
@@ -13,17 +14,24 @@ triggered a continuation, allow the next stop unconditionally.
 
 import json
 import os
-import re
 import sys
 
-PATTERN = re.compile(r"pre-?existing", re.IGNORECASE)
+NEEDLES = ("pre-existing", "preexisting")
+SENTENCE_DELIMS = (". ", "! ", "? ", "\n")
+MAX_QUOTES = 5
 
-BLOCK_REASON = (
-    'Your response contains "pre-existing" — this likely means you dismissed '
-    "errors without addressing them. Per project rules: if the error is small "
-    "(lint, unused import, type hint, sort order), fix it now. If larger, flag "
-    "each one explicitly to the user. Do not move on without either fixing or "
-    "flagging."
+BLOCK_PREAMBLE = (
+    "Your response contains the dismissal phrase in these passages "
+    "(the trigger is wrapped in >>>...<<<):"
+)
+
+BLOCK_TRAILER = (
+    "This likely means you dismissed errors without addressing them. "
+    "Per project rules: if the error is small (lint, unused import, "
+    "type hint, sort order), fix it now. If larger, flag each one "
+    "explicitly to the user. Do not move on without either fixing or "
+    "flagging. The word may only appear as factual context — never as "
+    "a reason to ignore a problem."
 )
 
 
@@ -59,7 +67,6 @@ def find_last_assistant_message(lines):
         if isinstance(msg, dict):
             content = msg.get("content", "")
             if isinstance(content, list):
-                # content blocks — extract text from text blocks
                 parts = []
                 for block in content:
                     if isinstance(block, dict) and block.get("type") == "text":
@@ -71,6 +78,131 @@ def find_last_assistant_message(lines):
             return msg
 
     return None
+
+
+def find_code_ranges(text):
+    """Return (start, end) ranges covering inline and fenced backtick code spans.
+
+    Treats any run of N backticks as opening a code span that closes at the
+    next run of exactly N backticks. Covers `inline`, ``with`backticks``, and
+    ```fenced``` blocks alike.
+    """
+    ranges = []
+    i = 0
+    n = len(text)
+    while i < n:
+        if text[i] != "`":
+            i += 1
+            continue
+        j = i
+        while j < n and text[j] == "`":
+            j += 1
+        tick_count = j - i
+        k = j
+        closed = False
+        while k < n:
+            if text[k] != "`":
+                k += 1
+                continue
+            m = k
+            while m < n and text[m] == "`":
+                m += 1
+            if m - k == tick_count:
+                ranges.append((i, m))
+                i = m
+                closed = True
+                break
+            k = m
+        if not closed:
+            i = j
+    return ranges
+
+
+def find_match_spans(text):
+    """Return sorted, deduplicated (start, end) spans for every needle hit
+    that falls outside any code span."""
+    code_ranges = find_code_ranges(text)
+
+    def in_code(pos):
+        for s, e in code_ranges:
+            if s <= pos < e:
+                return True
+        return False
+
+    text_lower = text.lower()
+    spans = set()
+    for needle in NEEDLES:
+        start = 0
+        while True:
+            idx = text_lower.find(needle, start)
+            if idx == -1:
+                break
+            if not in_code(idx):
+                spans.add((idx, idx + len(needle)))
+            start = idx + 1
+    return sorted(spans)
+
+
+def sentence_bounds(text, start, end):
+    """Return (sent_start, sent_end) bracketing the sentence around [start, end)."""
+    sent_start = 0
+    for delim in SENTENCE_DELIMS:
+        idx = text.rfind(delim, 0, start)
+        if idx != -1 and idx + len(delim) > sent_start:
+            sent_start = idx + len(delim)
+
+    sent_end = len(text)
+    for delim in SENTENCE_DELIMS:
+        idx = text.find(delim, end)
+        if idx != -1:
+            # Include the terminating punctuation, drop the trailing space/newline.
+            cand = idx + len(delim) - 1
+            if cand < sent_end:
+                sent_end = cand
+    return sent_start, sent_end
+
+
+def extract_quotes(text):
+    """Return a list of sentences containing matches, with each match highlighted."""
+    spans = find_match_spans(text)
+    if not spans:
+        return []
+
+    quotes = []
+    seen = set()
+    for span in spans:
+        sent_start, sent_end = sentence_bounds(text, span[0], span[1])
+        key = (sent_start, sent_end)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        # Highlight every match that falls inside this sentence.
+        pieces = []
+        cursor = sent_start
+        for s, e in spans:
+            if s < sent_start or e > sent_end:
+                continue
+            pieces.append(text[cursor:s])
+            pieces.append(">>>" + text[s:e] + "<<<")
+            cursor = e
+        pieces.append(text[cursor:sent_end])
+
+        # Collapse newlines so each quote sits on one line in the block reason.
+        quote = "".join(pieces).strip()
+        quote = " ".join(quote.split())
+        quotes.append(quote)
+
+    return quotes
+
+
+def build_reason(quotes):
+    shown = quotes[:MAX_QUOTES]
+    omitted = len(quotes) - len(shown)
+    numbered = "\n".join(f'  {i + 1}. "{q}"' for i, q in enumerate(shown))
+    if omitted > 0:
+        numbered += f"\n  ... and {omitted} more"
+    return f"{BLOCK_PREAMBLE}\n\n{numbered}\n\n{BLOCK_TRAILER}"
 
 
 def main():
@@ -91,9 +223,12 @@ def main():
     if not message:
         return
 
-    if PATTERN.search(message):
-        output = {"decision": "block", "reason": BLOCK_REASON}
-        print(json.dumps(output))
+    quotes = extract_quotes(message)
+    if not quotes:
+        return
+
+    output = {"decision": "block", "reason": build_reason(quotes)}
+    print(json.dumps(output))
 
 
 if __name__ == "__main__":

--- a/dot-claude-global/hooks/test_validate_commit_message.py
+++ b/dot-claude-global/hooks/test_validate_commit_message.py
@@ -85,6 +85,69 @@ class TestGitCommitDetection(unittest.TestCase):
         self.assertEqual(proc.returncode, 2, proc.stderr)
 
 
+class TestHeredocPatterns(unittest.TestCase):
+    """Multi-line commands with heredocs.
+
+    The agent's standard pattern for long commit messages is:
+        cat > /tmp/msg.txt <<EOF
+        <message>
+        EOF
+        git commit -F /tmp/msg.txt
+
+    Line 1 is the heredoc opener, not `git commit`. The earlier hook
+    inspected only line 1 and silently passed through every commit issued
+    this way. The new hook strips heredoc bodies and searches the rest.
+    """
+
+    def test_heredoc_to_file_then_commit_F_is_recognised(self):
+        # Real-world bypass: heredoc writes the message to disk, git
+        # commit reads it back. `git commit` lives on line 5.
+        bad = "fix(scope): too long\n\nLine 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6"
+        cmd = f"cat > /tmp/msg.txt <<'EOF'\n{bad}\nEOF\ngit commit -F /tmp/msg.txt"
+        proc = run_hook(cmd)
+        self.assertEqual(proc.returncode, 2, proc.stderr)
+        self.assertIn("Body has 6 non-empty lines", proc.stderr)
+
+    def test_setup_chain_then_commit_on_later_line_recognised(self):
+        # `git status` first, real commit on line 2. No heredoc.
+        proc = run_hook(f'git status\ngit commit -m "{SIX_LINE_BAD_BODY}"')
+        self.assertEqual(proc.returncode, 2, proc.stderr)
+
+    def test_git_commit_inside_heredoc_body_passes_through(self):
+        # The defense the original line-1 restriction was protecting:
+        # writing a shell script that contains the literal `git commit`
+        # must not trigger validation, because no commit is happening.
+        cmd = (
+            "cat > /tmp/script.sh <<'EOF'\n"
+            'git commit -m "this is a test fixture, not a real commit"\n'
+            "EOF\n"
+            "echo wrote script"
+        )
+        proc = run_hook(cmd)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    def test_heredoc_substitution_form_message_is_extracted(self):
+        # The CLAUDE.md canonical pattern: heredoc inside -m "$(cat <<EOF
+        # ... EOF)". The heredoc IS the message; extraction must find it.
+        cmd = (
+            "git commit -m \"$(cat <<'EOF'\n"
+            "fix(scope): too long\n\n"
+            "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6\n"
+            "EOF\n"
+            ')"'
+        )
+        proc = run_hook(cmd)
+        self.assertEqual(proc.returncode, 2, proc.stderr)
+        self.assertIn("Body has 6 non-empty lines", proc.stderr)
+
+    def test_indented_heredoc_dash_form_recognised(self):
+        # `<<-EOF` strips leading tabs; still a heredoc.
+        bad = "fix(scope): too long\n\nLine 1\nLine 2\nLine 3\nLine 4\nLine 5"
+        cmd = f"cat > /tmp/msg.txt <<-EOF\n{bad}\nEOF\ngit commit -F /tmp/msg.txt"
+        proc = run_hook(cmd)
+        self.assertEqual(proc.returncode, 2, proc.stderr)
+
+
 class TestNonCommitInvocations(unittest.TestCase):
     """Anything that isn't `git commit` must pass through (exit 0)."""
 

--- a/dot-claude-global/hooks/validate-commit-message.py
+++ b/dot-claude-global/hooks/validate-commit-message.py
@@ -72,6 +72,16 @@ GIT_COMMIT_RE = re.compile(
 # Examples: Co-Authored-By, Signed-off-by, Reviewed-by, Fixes.
 TRAILER_RE = re.compile(r"^[A-Z][A-Za-z]*(-[A-Za-z]+)*:\s.+$")
 
+# Match a heredoc block (the `<<TAG ... TAG` form with all four opening
+# variants: `<<TAG`, `<<'TAG'`, `<<"TAG"`, `<<-TAG`). Used to strip heredoc
+# bodies before searching for `git commit`: a test script body containing
+# the literal string `git commit` must not self-trigger, but a real
+# `git commit` invocation on a line after a heredoc must still be caught.
+HEREDOC_BODY_RE = re.compile(
+    r"<<-?\s*['\"]?(\w+)['\"]?\s*\n.*?\n\1\b",
+    re.DOTALL,
+)
+
 MAX_TITLE = 72
 MAX_BODY_LINES = 4
 MAX_BODY_LINE = 72
@@ -229,11 +239,14 @@ def main() -> None:
         pass_through()
 
     cmd = inp.get_input("command", "")
-    # Only inspect the invocation line itself; `git commit` substrings inside
-    # a heredoc body (e.g. test scripts piping Python with git references)
-    # would otherwise self-trigger.
-    invocation = cmd.split("\n", 1)[0]
-    if not GIT_COMMIT_RE.search(invocation):
+    # Strip heredoc bodies before searching: a `git commit` substring inside
+    # a heredoc body (e.g. a test script being cat'd to disk) must not
+    # self-trigger, but a real `git commit` invocation on a line other than
+    # the first must. The earlier `cmd.split("\n", 1)[0]` defense missed the
+    # very common `cat > /tmp/msg <<EOF ... EOF \n git commit -F /tmp/msg`
+    # pattern entirely — line 1 was just the heredoc opener.
+    sanitized = HEREDOC_BODY_RE.sub("", cmd)
+    if not GIT_COMMIT_RE.search(sanitized):
         pass_through()
     # --amend --no-edit reuses the prior message; nothing to validate.
     if is_amend_no_edit(cmd):


### PR DESCRIPTION
## TL;DR

Two small fixes to the stop hooks. The dismissal-warning hook now quotes the exact sentence that triggered it instead of a generic warning, and skips matches inside backtick code spans. The commit-message validator now catches commits invoked after a heredoc, which earlier silently passed through.

## Motivation

Two stop hooks in `dot-claude-global/hooks/` enforce house rules — one blocks turn-stops that dismiss errors, the other blocks malformed `git commit` invocations — and both had blind spots that let real misbehaviour through. The dismissal hook printed only a generic warning when it caught the trigger phrase, so Claude could not see which sentence flagged it and often had to re-read its own output to guess, especially when the phrase appeared inside a filename or code sample.

The commit-message validator inspected only the first line of the bash command, so whenever the agent used the canonical heredoc pattern — writing the message to a file with a heredoc, then `git commit -F` — line 1 was just the heredoc opener and the real commit on a later line silently passed through. Long, malformed commit bodies were therefore landing whenever that pattern was used.

## Summary

- Quote each sentence containing the trigger, with the phrase wrapped in `>>>...<<<` markers.
- Skip matches inside inline or fenced code spans so file paths and code samples do not trip.
- Strip heredoc bodies before searching, so `git commit` on a later line is caught.
- Add `TestHeredocPatterns` covering bare, quoted, dash-form, and substitution heredocs.
- All 23 validator tests pass.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>